### PR TITLE
Log Soup error with a description instead of id

### DIFF
--- a/extensions/webservice/harvest/harvest/harvest.py
+++ b/extensions/webservice/harvest/harvest/harvest.py
@@ -106,7 +106,9 @@ class Harvest(object):
 
         if message.status_code == 200:
             return True
-        self._logger.debug('could not send data: %d', message.status_code)
+        self._logger.debug('could not send data with code %d, %s',
+                           (message.status_code,
+                            Soup.status_get_phrase(message.status_code)))
         return False
 
     def _retry_valid(self):


### PR DESCRIPTION
for example, previously the log was:

```
could not send data: 4
```

and now is:

```
could not send data with code 4, Cannot connect to destination
```
